### PR TITLE
change submodules to not use ssh url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "esbuild-lib"]
 	path = lib/vendor/github.com/evanw/esbuild
-	url = git@github.com:wilsonzlin/esbuild-lib.git
+	url = https://github.com/wilsonzlin/esbuild-lib.git


### PR DESCRIPTION
this caused builds to silently break if an ssh key was not setup with git, which is sometimes the case on some setups

should have no impact on building or anything else though